### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,4 +1,6 @@
 name: Security Checks
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rtrimble13/configistate/security/code-scanning/3](https://github.com/rtrimble13/configistate/security/code-scanning/3)

To fix the problem, add a top-level `permissions` block in `.github/workflows/security.yml` right after the `name` and before the `on` key. This will limit the default token permissions for all jobs in the workflow, ensuring it only gets minimal access. Given that the workflow is running dependency and security checks (does not push, create, or modify code/PRs), `contents: read` is the minimal required permission and sufficient for such tasks. No changes are needed to specific jobs or steps, unless further permissions are required for any particular step (which can be overridden per job if needed in the future).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
