### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -1,4 +1,6 @@
 name: Python package
+permissions:
+  contents: read
 on: [push, pull_request]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/rtrimble13/configistate/security/code-scanning/2](https://github.com/rtrimble13/configistate/security/code-scanning/2)

To fix the issue, add an explicit `permissions` block at the workflow level in `.github/workflows/python-package.yaml`, just below the `name:` and before the `on:` key. Since this workflow only checks out code and runs tests, it does not require any write permissions—it only needs read access to the repository contents. Therefore, set the permissions to `contents: read`, which is minimal and best practice unless the workflow later requires more. No other changes to steps or jobs are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
