### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint & Format
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/rtrimble13/configistate/security/code-scanning/1](https://github.com/rtrimble13/configistate/security/code-scanning/1)

To fix the problem, explicitly set the minimal permissions this workflow needs. Since the job only checks out code and runs linter tools, only read access to repository contents is required via `contents: read`. This can be set either for the entire workflow (top-level, for all jobs), or specifically for the `lint` job. It's optimal to place this at the workflow root unless a job will need different permissions.

- Insert a `permissions:` block at the top level of the workflow, immediately after `name: Lint & Format`.
- The block should specify:
  ```yaml
  permissions:
    contents: read
  ```
- No special imports or methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
